### PR TITLE
feat: add pre-commit configuration

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,14 +2,5 @@
 
 Checklist
 ---------
-- [ ] Commit messages follows guideline format
+- [ ] Commits follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
 - [ ] Submitted code is covered by tests
-  * Bug: I have added at least one new test (to prevent regression)
-  * Chore: I have added/updated the corresponding tests
-  * Enhancement: I have added new tests to cover the new or improved
-    functionality
-  * Feature: I have added new tests to adequately cover the feature
-  * Other: I have made sure touched code is covered by existing automated
-    tests and/or manual testing plan
-  * Release: I have added the proper documentation for this new release
-  * Test: I have added at least one new test or updated an existing one

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -1,0 +1,14 @@
+name: pre-commit
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions/setup-python@v3
+    - uses: pre-commit/action@v3.0.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.0.1
+  hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer
+    - id: check-yaml
+    - id: check-json

--- a/app.py
+++ b/app.py
@@ -1,0 +1,1 @@
+print("Hello, World!")


### PR DESCRIPTION
Add a basic pre-commit configuration file and enable a GitHub action to
    run pre-commit on each pull request.

Checklist
---------
- [X] Commits follow the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/#specification)
- [ ] Submitted code is covered by tests
